### PR TITLE
Actually use the encoding the user gives

### DIFF
--- a/pybrat/parser.py
+++ b/pybrat/parser.py
@@ -342,7 +342,7 @@ class BratParser(object):
         }
 
     def _parse_text(self, txt, encoding):  # pylint: disable=no-self-use
-        with open(txt, mode="r") as f:
+        with open(txt, mode="r", encoding=encoding) as f:
             return f.read()
 
     def parse(


### PR DESCRIPTION
Sorry, I missed that you deleted the usage of the encoding in the edits of the last pull request - this should fix it!