### PR TITLE
fix unused "encoding" parameter in _parse_ann and add pattern of spaces

### DIFF
--- a/pybrat/parser.py
+++ b/pybrat/parser.py
@@ -398,9 +398,11 @@ class BratParser(object):
             encoding (str): Encoding for reading text files and
                 ann files
             text_preprocess_function (Optional[Callable[[str], str]]):
-                Function for text pre-processing
+                Function for text pre-processing, will be call on the
+                whole text file before parsing
             ann_preprocess_function (Optional[Callable[[str], str]]):
-                Function for annotation pre-processing
+                Function for annotation pre-processing, will be call on
+                each annotation line before parsing
 
         Returns:
             examples (list[Example]): Parsed examples.

--- a/pybrat/parser.py
+++ b/pybrat/parser.py
@@ -317,14 +317,17 @@ class BratParser(object):
                     )
                 )
 
-    def _parse_ann(self, ann, encoding):
+    def _parse_ann(self, ann, encoding, spaces_pattern):
         # Parser entities and store required data for parsing relations
         # and events.
         entity_matches, relation_matches, event_matches = [], [], []
         references = collections.defaultdict(list)
 
-        with open(ann, mode="r") as f:
+        with open(ann, mode="r", encoding=encoding) as f:
             for line in f:
+                if spaces_pattern is not None:
+                    line = re.sub(spaces_pattern, ' ', line)
+
                 line = line.rstrip()
                 if not line or line.startswith("#") or self._should_ignore_line(line):
                     continue
@@ -370,12 +373,15 @@ class BratParser(object):
             "events": list(events.values()),
         }
 
-    def _parse_text(self, txt, encoding):  # pylint: disable=no-self-use
+    def _parse_text(self, txt, encoding, spaces_pattern):  # pylint: disable=no-self-use
         with open(txt, mode="r", encoding=encoding) as f:
-            return f.read()
+            text = f.read()
+            if spaces_pattern is not None:
+                text = re.sub(spaces_pattern, ' ', text)
+            return text
 
     def parse(
-        self, dirname: Union[str, bytes, os.PathLike], encoding: str = "utf-8"
+        self, dirname: Union[str, bytes, os.PathLike], encoding: str = "utf-8", spaces_pattern: Optional[re.Pattern] = None
     ) -> list[Example]:
         """Parse examples in given directory.
 
@@ -384,6 +390,7 @@ class BratParser(object):
                 containing brat examples.
             encoding (str): Encoding for reading text files and
                 ann files
+            spaces_pattern (Optional[re.Pattern]): Pattern of spaces to be replaced with a single space
 
         Returns:
             examples (list[Example]): Parsed examples.
@@ -398,8 +405,8 @@ class BratParser(object):
         )
 
         for key, (ann_file, txt_file) in file_groups:
-            txt = self._parse_text(txt_file, encoding=encoding)
-            ann = self._parse_ann(ann_file, encoding=encoding)
+            txt = self._parse_text(txt_file, encoding=encoding, spaces_pattern=spaces_pattern)
+            ann = self._parse_ann(ann_file, encoding=encoding, spaces_pattern=spaces_pattern)
             examples += [Example(text=txt, **ann, id=key)]
 
         examples.sort(key=lambda x: x.id if x.id is not None else "")

--- a/pybrat/parser.py
+++ b/pybrat/parser.py
@@ -8,7 +8,7 @@ import itertools
 import os
 import re
 from collections.abc import Iterable
-from typing import Optional, Union, Callable
+from typing import Callable, Optional, Union
 
 from pybrat.utils import iter_file_groups
 
@@ -373,11 +373,14 @@ class BratParser(object):
             "events": list(events.values()),
         }
 
-    def _parse_text(self, txt, encoding, preprocess_function):  # pylint: disable=no-self-use
+    def _parse_text(
+        self, txt, encoding, preprocess_function
+    ):  # pylint: disable=no-self-use
         with open(txt, mode="r", encoding=encoding) as f:
             text = f.read()
             if preprocess_function is not None:
                 text = preprocess_function(text)
+
             return text
 
     def parse(
@@ -385,7 +388,7 @@ class BratParser(object):
         dirname: Union[str, bytes, os.PathLike],
         encoding: str = "utf-8",
         text_preprocess_function: Optional[Callable[[str], str]] = None,
-        ann_preprocess_function: Optional[Callable[[str], str]] = None
+        ann_preprocess_function: Optional[Callable[[str], str]] = None,
     ) -> list[Example]:
         """Parse examples in given directory.
 
@@ -394,8 +397,10 @@ class BratParser(object):
                 containing brat examples.
             encoding (str): Encoding for reading text files and
                 ann files
-            text_preprocess_function (Optional[Callable[[str], str]]): Function for text pre-processing
-            ann_preprocess_function (Optional[Callable[[str], str]]): Function for annotation pre-processing
+            text_preprocess_function (Optional[Callable[[str], str]]):
+                Function for text pre-processing
+            ann_preprocess_function (Optional[Callable[[str], str]]):
+                Function for annotation pre-processing
 
         Returns:
             examples (list[Example]): Parsed examples.
@@ -410,8 +415,14 @@ class BratParser(object):
         )
 
         for key, (ann_file, txt_file) in file_groups:
-            txt = self._parse_text(txt_file, encoding=encoding, preprocess_function=text_preprocess_function)
-            ann = self._parse_ann(ann_file, encoding=encoding, preprocess_function=ann_preprocess_function)
+            txt = self._parse_text(
+                txt_file,
+                encoding=encoding,
+                preprocess_function=text_preprocess_function,
+            )
+            ann = self._parse_ann(
+                ann_file, encoding=encoding, preprocess_function=ann_preprocess_function
+            )
             examples += [Example(text=txt, **ann, id=key)]
 
         examples.sort(key=lambda x: x.id if x.id is not None else "")


### PR DESCRIPTION
Hello! Thank you for your work. 
1. I add unused `encoding` parameter  in `_parse_ann`. It looks like you added this param but forgot to use it while reading the file. 
2. I add new parameter `spaces_pattern` for `BratParser.parse`. It's a pattern of spaces to be replaced with a single space.

**Example**

```python
brat = BratParser(error="ignore")

examples = brat.parse(my_dirname)
print(examples[0].text)
>>> "periods for 194\xa0countries for 2000–2013\xa0..."

pattern = re.compile(r'[\xa0]') 
examples2 = brat.parse(my_dirname, spaces_pattern=pattern)
print(examples2[0].text)
>>> "periods for 194 countries for 2000–2013 ..."
```
Similar behavior with annotations.